### PR TITLE
support keyword substitutions in query() variants

### DIFF
--- a/memsql/common/exceptions.py
+++ b/memsql/common/exceptions.py
@@ -4,3 +4,6 @@ class NotConnected(Exception):
 
 class RequiresDatabase(Exception):
     pass
+
+class FormatException(Exception):
+    pass

--- a/memsql/common/test/test_database.py
+++ b/memsql/common/test/test_database.py
@@ -1,0 +1,27 @@
+import pytest
+from memsql.common import database, exceptions
+
+memsql_required = pytest.mark.skipif(
+    "os.environ.get('TRAVIS') == 'true'",
+    reason="requires MemSQL connection"
+)
+
+
+@memsql_required
+def test_parameter_substitution(test_db_args, test_db_database):
+    with database.connect(**test_db_args) as conn:
+        conn.execute('CREATE DATABASE IF NOT EXISTS %s' % test_db_database)
+        conn.execute('USE %s' % test_db_database)
+        conn.execute('CREATE TABLE foo (a int primary key)')
+
+        conn.query('INSERT INTO foo VALUES (%s)', 3)
+        conn.query('INSERT INTO foo VALUES (%(val)s)', {'val' : 4})
+
+        conn.query('INSERT INTO foo VALUES ("3%s")')
+        conn.query('INSERT INTO foo VALUES ("3%(foo)s")')
+        conn.query('INSERT INTO foo VALUES ("3%s"), ("3%(foo)s")')
+
+        with pytest.raises(exceptions.FormatException):
+            conn.query('INSERT INTO foo VALUES (%s), %(foo)s' % 3)
+        with pytest.raises(exceptions.FormatException):
+            conn.query('INSERT INTO foo VALUES (%s), %(foo)s' % {'foo' : 3})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-ordereddict
-MySQL-python>=1.2.4
-wraptor
-netifaces
+MySQL-python==1.2.4
+Wraptor==0.5.0
+netifaces==0.8
+ordereddict==1.1
+py==1.4.18
+pytest==2.4.2
+wsgiref==0.1.2


### PR DESCRIPTION
Summary:
    - added *_kwparameters next to *parameters everywhere
    - pulled out _ensure_encoded function to use again
    - removed extraneous checks for None - None cant be produced by
      *args / *_kwargs type arguments
    - added tests
