### PR TITLE
Switch to store_result for performance

### DIFF
--- a/memsql/common/database.py
+++ b/memsql/common/database.py
@@ -146,7 +146,7 @@ class Connection(object):
     def _query(self, query, parameters, kwparameters, debug=False):
         self._execute(query, parameters, kwparameters, debug)
 
-        self._result = self._db.use_result()
+        self._result = self._db.store_result()
         if self._result is None:
             return self._rowcount
 


### PR DESCRIPTION
Going to let travis-ci check this out.  Found a issue with _mysql in which use_result grows the result buffer by 1000 rows each time.  This causes perf issues when the number of rows returned is much larger than 1000.