### PR TITLE
Add column Type to results, colname case insesitiveness

### DIFF
--- a/memsql/common/database.py
+++ b/memsql/common/database.py
@@ -4,7 +4,7 @@ import _mysql
 import time
 import operator
 import six
-from util import get_field_type_by_code
+from memsql.common import util
 
 try:
     from _thread import get_ident as _get_ident
@@ -151,7 +151,7 @@ class Connection(object):
         if self._result is None:
             return self._rowcount
 
-        fields = [ (f[0], get_field_type_by_code(f[1]), ) for f in self._result.describe() ]
+        fields = [ (f[0], util.get_field_type_by_code(f[1]), ) for f in self._result.describe() ]
         rows = self._result.fetch_row(0)
         return SelectResult(fields, rows)
 

--- a/memsql/common/database.py
+++ b/memsql/common/database.py
@@ -181,30 +181,30 @@ class Row(object):
     """A fast, ordered, partially-immutable dictlike object (or objectlike dict)."""
 
     def __init__(self, fields, values):
-        self._fields = fields
+        self._fields = map(lambda a:a.lower(), fields)
         self._values = values
 
     def __getattr__(self, name):
         try:
-            return self._values[self._fields.index(name)]
+            return self._values[self._fields.index(name.lower())]
         except (ValueError, IndexError):
             raise AttributeError(name)
 
     def __getitem__(self, name):
         try:
-            return self._values[self._fields.index(name)]
+            return self._values[self._fields.index(name.lower())]
         except (ValueError, IndexError):
             raise KeyError(name)
 
     def __setitem__(self, name, value):
         try:
-            self._values[self._fields.index(name)] = value
+            self._values[self._fields.index(name.lower())] = value
         except (ValueError, IndexError):
-            self._fields += (name,)
+            self._fields += (name.lower(),)
             self._values += (value,)
 
     def __contains__(self, name):
-        return name in self._fields
+        return name.lower() in self._fields
 
     has_key = __contains__
 
@@ -219,7 +219,7 @@ class Row(object):
 
     def get(self, name, default=None):
         try:
-            return self.__getitem__(name)
+            return self.__getitem__(name.lower())
         except KeyError:
             return default
 

--- a/memsql/common/database.py
+++ b/memsql/common/database.py
@@ -182,7 +182,7 @@ class Row(object):
     """A fast, ordered, partially-immutable dictlike object (or objectlike dict)."""
 
     def __init__(self, fields_and_types_tuple, values):
-        self._fields = map(lambda a: a[0].lower(), fields_and_types_tuple)
+        self._fields = list(map(lambda a: a[0].lower(), fields_and_types_tuple))
         self._values = values
         self._types = fields_and_types_tuple
 

--- a/memsql/common/database.py
+++ b/memsql/common/database.py
@@ -4,7 +4,7 @@ import _mysql
 import time
 import operator
 import six
-from util import get_type_by_id
+from util import get_field_type_by_code
 
 try:
     from _thread import get_ident as _get_ident
@@ -151,7 +151,7 @@ class Connection(object):
         if self._result is None:
             return self._rowcount
 
-        fields = [ (f[0], get_type_by_id(f[1]), ) for f in self._result.describe() ]
+        fields = [ (f[0], get_field_type_by_code(f[1]), ) for f in self._result.describe() ]
         rows = self._result.fetch_row(0)
         return SelectResult(fields, rows)
 

--- a/memsql/common/test/test_select_result.py
+++ b/memsql/common/test/test_select_result.py
@@ -9,34 +9,41 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
-FIELDS = ['l\\u203pez', 'ಠ_ಠ', 'cloud', 'moon', 'water', 'computer', 'school', 'network',
-          'hammer', 'walking', 'mediocre', 'literature', 'chair', 'two', 'window', 'cords', 'musical',
-          'zebra', 'xylophone', 'penguin', 'home', 'dog', 'final', 'ink', 'teacher', 'fun', 'website',
-          'banana', 'uncle', 'softly', 'mega', 'ten', 'awesome', 'attatch', 'blue', 'internet', 'bottle',
-          'tight', 'zone', 'tomato', 'prison', 'hydro', 'cleaning', 'telivision', 'send', 'frog', 'cup',
-          'book', 'zooming', 'falling', 'evily', 'gamer', 'lid', 'juice', 'moniter', 'captain', 'bonding']
+FIELDS = [('l\\u203pez', 'VARCHAR'), ('ಠ_ಠ', 'VARCHAR'), ('cloud', 'VARCHAR'), ('moon', 'VARCHAR'), ('water', 'VARCHAR'),
+          ('computer', 'VARCHAR'), ('school', 'VARCHAR'), ('network', 'VARCHAR'),
+          ('hammer', 'VARCHAR'), ('walking', 'VARCHAR'), ('mediocre', 'VARCHAR'), ('literature', 'VARCHAR'),
+          ('chair', 'VARCHAR'), ('two', 'VARCHAR'), ('window', 'VARCHAR'), ('cords', 'VARCHAR'), ('musical', 'VARCHAR'),
+          ('zebra', 'VARCHAR'), ('xylophone', 'VARCHAR'), ('penguin', 'VARCHAR'), ('home', 'VARCHAR'),
+          ('dog', 'VARCHAR'), ('final', 'VARCHAR'), ('ink', 'VARCHAR'), ('teacher', 'VARCHAR'), ('fun', 'VARCHAR'), ('website', 'VARCHAR'),
+          ('banana', 'VARCHAR'), ('uncle', 'VARCHAR'), ('softly', 'VARCHAR'), ('mega', 'VARCHAR'), ('ten', 'VARCHAR'),
+          ('awesome', 'VARCHAR'), ('attatch', 'VARCHAR'), ('blue', 'VARCHAR'), ('internet', 'VARCHAR'), ('bottle', 'VARCHAR'),
+          ('tight', 'VARCHAR'), ('zone', 'VARCHAR'), ('tomato', 'VARCHAR'), ('prison', 'VARCHAR'), ('hydro', 'VARCHAR'),
+          ('cleaning', 'VARCHAR'), ('telivision', 'VARCHAR'), ('send', 'VARCHAR'), ('frog', 'VARCHAR'), ('cup', 'VARCHAR'),
+          ('book', 'VARCHAR'), ('zooming', 'VARCHAR'), ('falling', 'VARCHAR'), ('evily', 'VARCHAR'), ('gamer', 'VARCHAR'),
+          ('lid', 'VARCHAR'), ('juice', 'VARCHAR'), ('moniter', 'VARCHAR'), ('captain', 'VARCHAR'), ('bonding', 'VARCHAR')]
 
 def test_result_order():
     raw_data = [[random.randint(1, 2 ** 32) for _ in range(len(FIELDS))] for _ in range(256)]
     res = database.SelectResult(FIELDS, raw_data)
 
     for i, row in enumerate(res):
-        reference = dict(zip(FIELDS, raw_data[i]))
-        ordered = OrderedDict(zip(FIELDS, raw_data[i]))
+        _FIELDS = map(lambda a: a[0], FIELDS)
+        reference = dict(zip(_FIELDS, raw_data[i]))
+        ordered = OrderedDict(zip(_FIELDS, raw_data[i]))
         doppel = database.Row(FIELDS, raw_data[i])
 
         assert doppel == row
         assert row == reference
         assert row == ordered
-        assert list(row.keys()) == FIELDS
+        assert list(row.keys()) == _FIELDS
         assert list(row.values()) == raw_data[i]
-        assert sorted(row) == sorted(FIELDS)
-        assert list(row.items()) == list(zip(FIELDS, raw_data[i]))
+        assert sorted(row) == sorted(_FIELDS)
+        assert list(row.items()) == list(zip(_FIELDS, raw_data[i]))
         assert list(row.values()) == raw_data[i]
-        assert list(row.keys()) == FIELDS
-        assert list(row.items()) == list(zip(FIELDS, raw_data[i]))
+        assert list(row.keys()) == _FIELDS
+        assert list(row.items()) == list(zip(_FIELDS, raw_data[i]))
 
-        for f in FIELDS:
+        for f in _FIELDS:
             assert f in row
             assert f in row
             assert row[f] == reference[f]

--- a/memsql/common/test/test_select_result.py
+++ b/memsql/common/test/test_select_result.py
@@ -27,7 +27,7 @@ def test_result_order():
     res = database.SelectResult(FIELDS, raw_data)
 
     for i, row in enumerate(res):
-        _FIELDS = map(lambda a: a[0], FIELDS)
+        _FIELDS = list(map(lambda a: a[0], FIELDS))
         reference = dict(zip(_FIELDS, raw_data[i]))
         ordered = OrderedDict(zip(_FIELDS, raw_data[i]))
         doppel = database.Row(FIELDS, raw_data[i])

--- a/memsql/common/util.py
+++ b/memsql/common/util.py
@@ -36,5 +36,6 @@ def timedelta_total_seconds(td):
     return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10. ** 6) / 10. ** 6
 
 
-def get_type_by_id(id):
+def get_field_type_by_code(id):
     return FIELD_TYPE_DICT.get(id, N_A_TYPE)
+

--- a/memsql/common/util.py
+++ b/memsql/common/util.py
@@ -1,3 +1,40 @@
+FIELD_TYPE_DICT = {
+ 0: 'DECIMAL',
+ 1: 'TINY',
+ 2: 'SHORT',
+ 3: 'LONG',
+ 4: 'FLOAT',
+ 5: 'DOUBLE',
+ 6: 'NULL',
+ 7: 'TIMESTAMP',
+ 8: 'LONGLONG',
+ 9: 'INT24',
+ 10: 'DATE',
+ 11: 'TIME',
+ 12: 'DATETIME',
+ 13: 'YEAR',
+ 14: 'NEWDATE',
+ 15: 'VARCHAR',
+ 16: 'BIT',
+ 246: 'NEWDECIMAL',
+ 247: 'INTERVAL',
+ 248: 'SET',
+ 249: 'TINY_BLOB',
+ 250: 'MEDIUM_BLOB',
+ 251: 'LONG_BLOB',
+ 252: 'BLOB',
+ 253: 'VAR_STRING',
+ 254: 'STRING',
+ 255: 'GEOMETRY'
+}
+
+N_A_TYPE = 'N/A'
+
+
 def timedelta_total_seconds(td):
     """ Needed for python 2.6 compat """
     return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10. ** 6) / 10. ** 6
+
+
+def get_type_by_id(id):
+    return FIELD_TYPE_DICT.get(id, N_A_TYPE)


### PR DESCRIPTION
consists of two small features:

1. add the ability to be case insensitive when getting columns from result Row.
    i.e.   if we have column SOMECOLUMN  in db, all of those will work :
                         res.someColumn, res.somecolumn, res.SOMECOLUMN etc...
2. add the ability to get the column type.
    (_result.describe() returns the 7 elm tuple, and currently we use only the column name and sometimes there is a need to know the type also)