### PR TITLE
Relax version constraints for six and dateutil.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ import sys
 REQUIREMENTS = [
     'wraptor',
     'simplejson',
-    'python-dateutil==2.2',
-    'six==1.11.0'
+    'python-dateutil>=2.2,<3.0',
+    'six>=1.11.0'
 ]
 
 if sys.version_info[0] == 3:


### PR DESCRIPTION
In Redash we have some dependencies that also require six and dateutil, and the version pinning for both dependency conflicts with theirs.

Since both six and dateutils are fairly API-stable I think it's okay to relax the constraints a bit.