### PR TITLE
Relax version constraints for some dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,8 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     packages=[
         'memsql',

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ import sys
 REQUIREMENTS = [
     'wraptor',
     'simplejson',
-    'python-dateutil==2.2',
-    'six==1.11.0'
+    'python-dateutil<3.0',
+    'six',
 ]
 
 if sys.version_info[0] == 3:
-    REQUIREMENTS.append('mysqlclient==1.3.6')
+    REQUIREMENTS.append('mysqlclient<1.4.0')
 elif sys.version_info[0] == 2:
     REQUIREMENTS.append('MySQL-python==1.2.5')
 else:


### PR DESCRIPTION
Six, mysqlclient and python-dateutil are often depended on in other libaries,
which means pinning their version in memsql-python is an issue during
installation when using pip and effectively prevents your users to follow
best practices to stay up-to-date with updates -- at least for minor releases.

Since six is very stable (maintained by Python core devs),
dateutil has a [very clear change history](https://github.com/dateutil/dateutil/blob/master/NEWS)
and mysqlient has received a [number of fixes](https://github.com/PyMySQL/mysqlclient-python/blob/master/HISTORY.rst#whats-new-in-1314)
I suggest to:

- remove version constraint on six completely
- relax version constraint on dateutil to `<3.0`
- relax version constrain on mysqlclient to `<1.4.0`
- configure Travis to automatically run the tests every day with their
  [cron jobs](https://docs.travis-ci.com/user/cron-jobs/) to catch API
  inconsistencies introduced by minor versions (if at all)

What do you think?

PS: Any reason to still have Python 2.6 supported by this package?