### PR TITLE
Relax version constraints for six and dateutil.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,8 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     packages=[
         'memsql',

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ import sys
 REQUIREMENTS = [
     'wraptor',
     'simplejson',
-    'python-dateutil==2.2',
-    'six==1.11.0'
+    'python-dateutil<3.0',
+    'six',
 ]
 
 if sys.version_info[0] == 3:


### PR DESCRIPTION
Replaces #14.

Six and python-dateutil are often depended on in other libaries,
which means pinning their version in memsql-python is an issue during
installation when using pip and effectively prevents your users to follow
best practices to stay up-to-date with updates -- at least for minor releases.

Since six is very stable (maintained by Python core devs) and dateutil
has a [very clear change history](https://github.com/dateutil/dateutil/blob/master/NEWS)
I suggest to:

- remove version constraint on six completely
- relax version constraint on dateutil to `<3.0`
- configure Travis to automatically run the tests every day with their
  [cron jobs](https://docs.travis-ci.com/user/cron-jobs/) to catch API
  inconsistencies introduced by minor versions (if at all)

What do you think?